### PR TITLE
Clarify frequency 0 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Chunks are pumped out via standard readable stream spec:
 		assert.isTrue(data instanceof Buffer);
 	});
 
-Chunks are pumped out by the interval that you specified in frequency. Setting the frequency to 0 will immediately stream the data (also in chunks). This is useful for unit testing.
+Chunks are pumped out by the interval that you specified in frequency. Setting the frequency to 0 will immediately stream the data (also in chunks), even if the stream has not been piped to a destination. This is useful for unit testing. 
 
 setEncoding() for streams is respected too:
 


### PR DESCRIPTION
@samcday Tremendously useful library you have here. And kudos to @Sunib for the new frequency 0 feature added in #7. In fact, I always assumed that frequency 0 was already supported. :flushed: 

I added some clarification to the readme that may be helpful. I had some unit tests that set frequency to 0 I had to fix when upgrading to the latest version of stream-buffers. (Really easy -- in most cases I piped the readable stream buffer to a destination stream prior to inserting data into the buffer.) 

Lastly, as a future enhancement, when frequency is set to 0 I suggest starting the readable stream buffer  paused. It's standard streams2 behavior as node 0.10 to wait until consumers are ready before emitting data. 
