### PR TITLE
Add callback to .write()

### DIFF
--- a/lib/writable_streambuffer.js
+++ b/lib/writable_streambuffer.js
@@ -64,7 +64,7 @@ var WritableStreamBuffer = module.exports = function(opts) {
 		}
 	};
 
-	this.write = function(data, encoding) {
+	this.write = function(data, encoding, callback) {
 		if(!that.writable) return;
 
 		if(Buffer.isBuffer(data)) {
@@ -78,6 +78,8 @@ var WritableStreamBuffer = module.exports = function(opts) {
 			buffer.write(data, size, encoding || "utf8");
 			size += Buffer.byteLength(data);
 		}
+		
+		if(typeof callback === "function") { callback() ;}
 	};
 
 	this.end = function() {


### PR DESCRIPTION
Current node versions (0.10+?) have an optional callback argument which should be called when the data is flushed.

```
Function Callback for when this chunk of data is flushed
```

http://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback