### PR TITLE
Fix null pointer in ReadableStreamBuffer

### DIFF
--- a/lib/readable_streambuffer.js
+++ b/lib/readable_streambuffer.js
@@ -113,7 +113,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
 
 	this.destroy = function() {
 		that.emit("end");
-		if(sendData.interval) clearInterval(sendData.interval);
+		if(sendData && sendData.interval) clearInterval(sendData.interval);
 		sendData = null;
 		that.readable = false;
 		that.emit("close");
@@ -121,7 +121,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
 
 	this.destroySoon = function() {
 		that.readable = false;
-		if (!sendData.interval) {
+		if (!sendData || !sendData.interval) {
 			that.emit("end");
 			that.emit("close");
 		}


### PR DESCRIPTION
Fixed bug where we weren't checking if sendData existed before using its attributes.