### PR TITLE
Bug Fixed: stream not closed if empty and destroy not called

### DIFF
--- a/lib/readable_streambuffer.js
+++ b/lib/readable_streambuffer.js
@@ -40,7 +40,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
 			size -= amount;
 		}
 
-		if(size === 0 && !that.readable) {
+		if(size === 0 || !that.readable) {
 			that.emit("end");
 			that.emit("close");
 			if (sendData && sendData.interval) {

--- a/test/readable_streambuffer.test.js
+++ b/test/readable_streambuffer.test.js
@@ -229,7 +229,6 @@ vows.describe("ReadableStreamBuffer").addBatch({
 			});
 
 			aStreamBuffer.put(fixtures.simpleString);
-			aStreamBuffer.destroySoon();
 		},
 
 		"chunks equal original value": function(chunks) {
@@ -273,7 +272,6 @@ vows.describe("ReadableStreamBuffer").addBatch({
 				chunks.push(data);
 				if(chunks.length == 2) that.callback(null, chunks);
 			});
-			aStreamBuffer.destroySoon();
 		},
 		"is chunked correctly": function(data) {
 			assert.equal(data[0], "Hello");


### PR DESCRIPTION
If destroy method is not called and buffer become empty, stream should destroy itself.