### PR TITLE
Fix Issue #30 where ReadableStreamBuffer stalls in certain cases.

### DIFF
--- a/lib/readable_streambuffer.js
+++ b/lib/readable_streambuffer.js
@@ -19,6 +19,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
 
   var size = 0;
   var buffer = new Buffer(initialSize);
+  var allowPush = false;
 
   var sendData = function() {
     var amount = Math.min(chunkSize, size);
@@ -30,6 +31,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
       buffer.copy(chunk, 0, 0, amount);
 
       sendMore = that.push(chunk) !== false;
+      allowPush = sendMore;
 
       buffer.copy(buffer, 0, amount, size);
       size -= amount;
@@ -76,6 +78,12 @@ var ReadableStreamBuffer = module.exports = function(opts) {
     }
   };
 
+  var kickSendDataTask = function () {
+    if (!sendData.timeout && allowPush) {
+      sendData.timeout = setTimeout(sendData, frequency);
+    }
+  }
+
   this.put = function(data, encoding) {
     if (that.stopped) {
       throw new Error('Tried to write data to a stopped ReadableStreamBuffer');
@@ -93,12 +101,13 @@ var ReadableStreamBuffer = module.exports = function(opts) {
       buffer.write(data, size, encoding || 'utf8');
       size += dataSizeInBytes;
     }
+
+    kickSendDataTask();
   };
 
   this._read = function() {
-    if (!sendData.timeout) {
-      sendData.timeout = setTimeout(sendData, frequency);
-    }
+    allowPush = true;
+    kickSendDataTask();
   };
 };
 

--- a/test/readable_streambuffer.test.js
+++ b/test/readable_streambuffer.test.js
@@ -55,6 +55,23 @@ describe('A default ReadableStreamBuffer', function() {
     this.buffer.stop();
   });
 
+  it('pushes new data even if read when empty', function(done) {
+    var that = this;
+    var str = '';
+    this.buffer.on('readable', function() {
+      str += (that.buffer.read() || new Buffer(0)).toString('utf8');
+    });
+    this.buffer.on('end', function() {
+      expect(str).to.equal(fixtures.unicodeString);
+      done();
+    });
+
+    setTimeout(function() {
+      that.buffer.put(fixtures.unicodeString);
+      that.buffer.stop();
+    }, streamBuffer.DEFAULT_FREQUENCY + 1);
+  });
+
   describe('when writing binary data', function() {
     beforeEach(function(done) {
       var that = this;


### PR DESCRIPTION
The root cause of issue30 is that the `sendData` timeout can expire with no data.  When this happens, and data is later put into the `ReadableStreamBuffer`, nothing schedules the `sendData` timeout (since _read will not be called again, unless the stream is paused and unpaused, etc.).

This fix will kick the `sendData` task on `put` if there is no pending timeout and push is allowed (i.e.,  `_read` was called and `buffer.push` did not return `false`).