### PR TITLE
Remove use of deprecated Buffer constructor

### DIFF
--- a/lib/readable_streambuffer.js
+++ b/lib/readable_streambuffer.js
@@ -18,7 +18,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
   var incrementAmount = opts.incrementAmount || constants.DEFAULT_INCREMENT_AMOUNT;
 
   var size = 0;
-  var buffer = new Buffer(initialSize);
+  var buffer = Buffer.alloc(initialSize);
   var allowPush = false;
 
   var sendData = function() {
@@ -27,7 +27,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
 
     if (amount > 0) {
       var chunk = null;
-      chunk = new Buffer(amount);
+      chunk = Buffer.alloc(amount);
       buffer.copy(chunk, 0, 0, amount);
 
       sendMore = that.push(chunk) !== false;
@@ -72,7 +72,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
     if((buffer.length - size) < incomingDataSize) {
       var factor = Math.ceil((incomingDataSize - (buffer.length - size)) / incrementAmount);
 
-      var newBuffer = new Buffer(buffer.length + (incrementAmount * factor));
+      var newBuffer = Buffer.alloc(buffer.length + (incrementAmount * factor));
       buffer.copy(newBuffer, 0, 0, size);
       buffer = newBuffer;
     }

--- a/lib/writable_streambuffer.js
+++ b/lib/writable_streambuffer.js
@@ -13,7 +13,7 @@ var WritableStreamBuffer = module.exports = function(opts) {
   var initialSize = opts.initialSize || constants.DEFAULT_INITIAL_SIZE;
   var incrementAmount = opts.incrementAmount || constants.DEFAULT_INCREMENT_AMOUNT;
 
-  var buffer = new Buffer(initialSize);
+  var buffer = Buffer.alloc(initialSize);
   var size = 0;
 
   this.size = function() {
@@ -27,7 +27,7 @@ var WritableStreamBuffer = module.exports = function(opts) {
   this.getContents = function(length) {
     if(!size) return false;
 
-    var data = new Buffer(Math.min(length || size, size));
+    var data = Buffer.alloc(Math.min(length || size, size));
     buffer.copy(data, 0, 0, data.length);
 
     if(data.length < size)
@@ -55,7 +55,7 @@ var WritableStreamBuffer = module.exports = function(opts) {
     if((buffer.length - size) < incomingDataSize) {
       var factor = Math.ceil((incomingDataSize - (buffer.length - size)) / incrementAmount);
 
-      var newBuffer = new Buffer(buffer.length + (incrementAmount * factor));
+      var newBuffer = Buffer.alloc(buffer.length + (incrementAmount * factor));
       buffer.copy(newBuffer, 0, 0, size);
       buffer = newBuffer;
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Sam Day <me@samcday.com.au>",
   "main": "./lib/streambuffer.js",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4.5.0"
   },
   "dependencies": {},
   "devDependencies": {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -4,13 +4,13 @@ var streamBuffer = require('../lib/streambuffer');
 
 var simpleString = 'This is a String!';
 var unicodeString = '\u00bd + \u00bc = \u00be';
-var binaryData = new Buffer(64);
+var binaryData = Buffer.alloc(64);
 for(var i = 0; i < binaryData.length; i++) {
   binaryData[i] = i;
 }
 
 // Binary data larger than initial size of buffers.
-var largeBinaryData = new Buffer(streamBuffer.DEFAULT_INITIAL_SIZE + 1);
+var largeBinaryData = Buffer.alloc(streamBuffer.DEFAULT_INITIAL_SIZE + 1);
 for(i = 0; i < largeBinaryData.length; i++) {
   largeBinaryData[i] = i % 256;
 }

--- a/test/readable_streambuffer.test.js
+++ b/test/readable_streambuffer.test.js
@@ -45,7 +45,7 @@ describe('A default ReadableStreamBuffer', function() {
     var that = this;
     var str = '';
     this.buffer.on('readable', function() {
-      str += (that.buffer.read() || new Buffer(0)).toString('utf8');
+      str += (that.buffer.read() || Buffer.alloc(0)).toString('utf8');
     });
     this.buffer.on('end', function() {
       expect(str).to.equal(fixtures.unicodeString);
@@ -59,7 +59,7 @@ describe('A default ReadableStreamBuffer', function() {
     var that = this;
     var str = '';
     this.buffer.on('readable', function() {
-      str += (that.buffer.read() || new Buffer(0)).toString('utf8');
+      str += (that.buffer.read() || Buffer.alloc(0)).toString('utf8');
     });
     this.buffer.on('end', function() {
       expect(str).to.equal(fixtures.unicodeString);


### PR DESCRIPTION
Fixes deprecation warnings. This change does require bumping the minimum required Node.js version, but the EOL of v0.10 was over four years ago (and even v4 has, in fact, been EOL for three)